### PR TITLE
Makefile fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,34 @@
 PROJECT = "Pd Remote VS Code"
 VERSION=${shell cat package.json | grep version | cut -d '"' -f 4}
+PACKAGE = pd-remote-vscode-${VERSION}.vsix
 
-build:
-	@echo "Building $(PROJECT)..."
+all: $(PACKAGE)
+
+# This needs to be run once, as root, or nothing will work.
+install-vsce:
+	@echo "Installing vsce..."
 	npm install -g @vscode/vsce
-	vsce package
-	@echo "Done."
 
-install:
+# If it isn't needed any more.
+uninstall-vsce:
+	@echo "Uninstalling vsce..."
+	npm uninstall -g @vscode/vsce
+
+$(PACKAGE): node_modules package.json src/extension.ts
+	@echo "Building $(PROJECT)..."
+	vsce package
+
+node_modules:
+	@echo "Installing dependencies..."
+	npm install
+
+# Do *not* run this as root.
+install: all
 	@echo "Installing $(PROJECT)..."
 	@echo "Version: $(VERSION)"
-	code --install-extension pd-remote-vscode-${VERSION}.vsix
-	@echo "Done."
+	code --install-extension $(PACKAGE)
+
+# Delete build artifacts.
+clean:
+	@echo "Cleaning $(PROJECT)..."
+	rm -rf node_modules out *.vsix

--- a/README.md
+++ b/README.md
@@ -1,14 +1,18 @@
 # pd-remote-vscode README
 
-This extension aims to mirror the features of Albert Graefs Emacs-based [Pd-Remote](https://github.com/agraef/pd-remote) as a Visual Studio Code Extension.
+This extension aims to mirror the features of Albert Gräf's Emacs-based [Pd-Remote](https://github.com/agraef/pd-remote) as a Visual Studio Code Extension.
+
+## Pre-requisites
+
+The @vscode/vsce module needs to be installed globally, or nothing will work. To these ends, run `sudo make install-vsce` OR `sudo npm install -g @vscode/vsce` once.
 
 ## Packaging the extension
 
-### Run `make build` OR
+### Run `make` OR
 
-1. Install VS Codes extension manager vsce from npm  
-```npm install -g @vscode/vsce```
-2. In the repositorys root directory, run  
+1. To install requisite modules using npm, run  
+```npm install```
+2. To package the extension, run  
 ```vsce package```
 
 ## Installing the extension
@@ -30,7 +34,7 @@ This extension aims to mirror the features of Albert Graefs Emacs-based [Pd-Remo
 
 ## Usage
 
-You may use the [examples in Albert Graefs Repository](https://github.com/agraef/pd-remote/tree/main/examples) to test the extension.
+You may use the [examples in Albert Gräf's Repository](https://github.com/agraef/pd-remote/tree/main/examples) to test the extension.
 The default connection is opened on localhost:4711 over UDP. You may change these values in VSCodes workspace or user settings.
 
 ### Supported Commands

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pd-remote-vscode",
-  "version": "0.0.1",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pd-remote-vscode",
-      "version": "0.0.1",
+      "version": "1.0.1",
       "devDependencies": {
         "@types/glob": "^8.0.1",
         "@types/mocha": "^10.0.1",


### PR DESCRIPTION
I'm not into vscode and npm that much, so there may be better ways to do this, but I think that this should do for now.

- Breaks out the global vsce installation into its own target, which is the only target that needs to be run as root.
- Runs `npm install` as needed.
- Takes care of dependencies, to avoid unnecessary rebuilds.
- Added clean target which gets rid of all build artifacts, including locally installed modules.

Fixes #2.